### PR TITLE
bugfix: show deleted recent tags in autocomplete HASH-113

### DIFF
--- a/src/components/note-editor/note-editor.ts
+++ b/src/components/note-editor/note-editor.ts
@@ -388,7 +388,12 @@ export class NoteEditorComponent {
     const allNoteUniqueHashtags = this.getAllNoteUniqueHashtagsSorted({
       pattern,
     });
-
+    this.recentHashtagsProvider.hashtags.forEach((hashtag: string): void => {
+      if (!allNoteUniqueHashtags.includes(hashtag)) {
+        allNoteUniqueHashtags.push(hashtag);
+      }
+    });
+    allNoteUniqueHashtags.sort();
     const lowerCasePattern = pattern.toLocaleLowerCase();
     const suggestedHashtags =
       pattern.length === 0
@@ -438,11 +443,6 @@ export class NoteEditorComponent {
       noteToIgnore: this.note,
     });
     noteUniqueHashtags.forEach((hashtag: string): void => {
-      if (!allNoteUniqueHashtags.includes(hashtag)) {
-        allNoteUniqueHashtags.push(hashtag);
-      }
-    });
-    this.recentHashtagsProvider.hashtags.forEach((hashtag: string): void => {
       if (!allNoteUniqueHashtags.includes(hashtag)) {
         allNoteUniqueHashtags.push(hashtag);
       }


### PR DESCRIPTION
### Change

display recent tags in autocomplete menu even when they have been deleted from all notes


